### PR TITLE
fix: Unable to format tables where cell contains double quotes

### DIFF
--- a/lib/format.ex
+++ b/lib/format.ex
@@ -26,5 +26,7 @@ defmodule ExTypst.Format do
   defp format_column_element(e) when is_integer(e) or is_binary(e), do: add_quotes(e)
   defp format_column_element(unknown), do: unknown |> inspect() |> add_quotes()
 
-  defp add_quotes(s), do: "\"#{s}\""
+  # use brackets for the cell content instead of double quotes, this seems to be 
+  # the preferred syntax for typst now
+  defp add_quotes(s), do: "[#{s}]"
 end


### PR DESCRIPTION
Hi, I think the title says it all, here in more details:


The at the time of commit way to add table cell data in typst is to use brackets [content of cell], instead of using double quotes: "content of cell", 

Without this change we cannot commit table cells that contain a double quote, i.e. this in Elixir:

"do \"some\" thing"

will throw an error.


Note that I am not a typst expert, but some testing showed me that with the brackets I can still have a table cell with content that has brackets, e.g. in Elixir "do [some] thing" will work just fine with this change